### PR TITLE
Set annotation frame using autoresizing mask

### DIFF
--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -22,14 +22,8 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         annotation = mapAnnotation.annotation
 
         let controller = NativeHostingController(rootView: mapAnnotation.content)
-        controller.view.translatesAutoresizingMaskIntoConstraints = false
         addSubview(controller.view)
-        NSLayoutConstraint.activate([
-            controller.view.centerXAnchor.constraint(equalTo: centerXAnchor),
-            controller.view.centerYAnchor.constraint(equalTo: centerYAnchor),
-            controller.view.widthAnchor.constraint(equalTo: widthAnchor),
-            controller.view.heightAnchor.constraint(equalTo: heightAnchor),
-        ])
+        bounds.size = controller.preferredContentSize
         self.controller = controller
     }
 

--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -29,6 +29,14 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
 
     // MARK: Overrides
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        if let controller = controller {
+            bounds.size = controller.preferredContentSize
+        }
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
 


### PR DESCRIPTION
Changelog:

- Instead of relying on autolayout to determine the size of an annotation view, we use the autoresizing mask