### PR TITLE
Annotation selection

### DIFF
--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -15,19 +15,33 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
     // MARK: Stored Properties
 
     private var controller: NativeHostingController<Content>?
+    private var selectedContent: Content?
+    private var notSelectedContent: Content?
+    private var viewMapAnnotation: ViewMapAnnotation<Content>?
 
     // MARK: Methods
 
     func setup(for mapAnnotation: ViewMapAnnotation<Content>) {
         annotation = mapAnnotation.annotation
-
-        let controller = NativeHostingController(rootView: mapAnnotation.content)
+        self.viewMapAnnotation = mapAnnotation
+        updateContent(for: self.isSelected)
+    }
+    
+    private func updateContent(for selectedState: Bool) {
+        guard let contentView = selectedState ? viewMapAnnotation?.selectedContent : viewMapAnnotation?.content else {
+            return
+        }
+        controller?.view.removeFromSuperview()
+        let controller = NativeHostingController(rootView: contentView)
         addSubview(controller.view)
         bounds.size = controller.preferredContentSize
         self.controller = controller
     }
 
     // MARK: Overrides
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        updateContent(for: selected)
+    }
 
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -47,7 +61,6 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         controller?.removeFromParent()
         controller = nil
     }
-
 }
 
 #endif

--- a/Sources/Annotations/ViewMapAnnotation.swift
+++ b/Sources/Annotations/ViewMapAnnotation.swift
@@ -42,6 +42,7 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
 
     public let annotation: MKAnnotation
     let content: Content
+    let selectedContent: Content
 
     // MARK: Initialization
 
@@ -49,18 +50,22 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
         coordinate: CLLocationCoordinate2D,
         title: String? = nil,
         subtitle: String? = nil,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder selectedContent: () -> Content? = { nil }
     ) {
         self.annotation = Annotation(coordinate: coordinate, title: title, subtitle: subtitle)
         self.content = content()
+        self.selectedContent = selectedContent() ?? content()
     }
 
     public init(
         annotation: MKAnnotation,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder selectedContent: () -> Content? = { nil }
     ) {
         self.annotation = annotation
         self.content = content()
+        self.selectedContent = selectedContent() ?? content()
     }
 
     // MARK: Methods

--- a/Sources/Map/Map+Coordinator.swift
+++ b/Sources/Map/Map+Coordinator.swift
@@ -46,6 +46,7 @@ extension Map {
             defer { view = newView }
             let animation = context.transaction.animation
             updateAnnotations(on: mapView, from: view, to: newView)
+            updateSelectedItem(on: mapView, from: view, to: newView)
             updateCamera(on: mapView, context: context, animated: animation != nil)
             updateInformationVisibility(on: mapView, from: view, to: newView)
             updateInteractionModes(on: mapView, from: view, to: newView)
@@ -194,6 +195,20 @@ extension Map {
                 }
             }
         }
+        
+        private func updateSelectedItem(on mapView: MKMapView, from previousView: Map?, to newView: Map) {
+            // Make sure the selectedItem is changed
+            guard newView.selectedItem != previousView?.selectedItem else { return }
+            
+            // New item is selected
+            if let newSelectedItem = newView.selectedItem,
+               let mapAnnotation = annotationContentByID[newSelectedItem] {
+                mapView.selectAnnotation(mapAnnotation.annotation, animated: false)
+            } else {
+                // No item is selected
+                mapView.selectedAnnotations = []
+            }
+        }
 
         private func updatePointOfInterestFilter(on mapView: MKMapView, from previousView: Map?, to newView: Map) {
             if previousView?.pointOfInterestFilter != newView.pointOfInterestFilter {
@@ -294,7 +309,19 @@ extension Map {
             }
             return content.view(for: mapView)
         }
-
+        
+        public func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+            // Find the item ID of the selected annotation
+            guard let id = annotationContentByID.first(where: { $0.value.annotation === view.annotation })?.key else {
+                return
+            }
+            // Assing the selected item ID to the selectedItem binding
+            self.view?.selectedItem = id
+        }
+        
+        public func mapView(_ mapView: MKMapView, didDeselect view: MKAnnotationView) {
+            self.view?.selectedItem = nil
+        }
     }
 
     // MARK: Methods

--- a/Sources/Map/Map+Watch+Coordinator.swift
+++ b/Sources/Map/Map+Watch+Coordinator.swift
@@ -92,7 +92,6 @@ extension Map: WKInterfaceObjectRepresentable {
                 mapView.setUserTrackingMode(newView.userTrackingMode, animated: animated)
             }
         }
-
     }
 
     // MARK: Methods

--- a/Sources/Map/Map.swift
+++ b/Sources/Map/Map.swift
@@ -32,6 +32,7 @@ public struct Map<AnnotationItems: RandomAccessCollection, OverlayItems: RandomA
     @Binding var userTrackingMode: MKUserTrackingMode
 
     let annotationItems: AnnotationItems
+    @Binding var selectedItem: AnnotationItems.Element.ID?
     let annotationContent: (AnnotationItems.Element) -> MapAnnotation
 
     let overlayItems: OverlayItems
@@ -178,6 +179,7 @@ extension Map {
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<MKUserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
+        selectedItem: Binding<AnnotationItems.Element.ID?> = .constant(.none),
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
@@ -197,6 +199,7 @@ extension Map {
             self._userTrackingMode = .constant(.none)
         }
         self.annotationItems = annotationItems
+        self._selectedItem = selectedItem
         self.annotationContent = annotationContent
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
@@ -210,6 +213,7 @@ extension Map {
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<MKUserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
+        selectedItem: Binding<AnnotationItems.Element.ID?> = .constant(.none),
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
@@ -232,6 +236,7 @@ extension Map {
         self.annotationContent = annotationContent
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
+        self._selectedItem = selectedItem
     }
 
 }
@@ -391,6 +396,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
+            selectedItem: .constant(.none),
             annotationContent: { annotationContent($0.object) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
@@ -508,6 +514,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<MKUserTrackingMode>?,
         annotationItems: AnnotationItems,
+        selectedItem: Binding<AnnotationItems.Element.ID?>,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
@@ -525,6 +532,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
             annotationItems: annotationItems,
+            selectedItem: selectedItem,
             annotationContent: annotationContent,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
@@ -577,6 +585,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<MKUserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
+        selectedItem: Binding<AnnotationItems.Element.ID?>,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
@@ -594,6 +603,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
             annotationItems: annotationItems,
+            selectedItem: selectedItem,
             annotationContent: annotationContent,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
@@ -814,6 +824,7 @@ extension Map
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
+            selectedItem: .constant(.none),
             annotationContent: { annotationContent($0.object) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }


### PR DESCRIPTION
Annotation selection

- `ViewMapAnnotation` extended for `selectedContent` = content to display when the annotation is selected
- `Map` initializers extended for `selectedItem` binding - allows to observe the selected item and set it from code (apart from the user tap manual selection) 