### PR TITLE
Add clustering support

### DIFF
--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -20,6 +20,7 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
 
     func setup(for mapAnnotation: ViewMapAnnotation<Content>) {
         annotation = mapAnnotation.annotation
+        clusteringIdentifier = mapAnnotation.clusteringIdentifier
 
         let controller = NativeHostingController(rootView: mapAnnotation.content)
         addSubview(controller.view)
@@ -29,6 +30,8 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
 
     // MARK: Overrides
 
+    #if canImport(UIKit)
+
     override func layoutSubviews() {
         super.layoutSubviews()
 
@@ -36,6 +39,8 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
             bounds.size = controller.preferredContentSize
         }
     }
+
+    #endif
 
     override func prepareForReuse() {
         super.prepareForReuse()

--- a/Sources/Annotations/ViewMapAnnotation.swift
+++ b/Sources/Annotations/ViewMapAnnotation.swift
@@ -41,6 +41,7 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
     // MARK: Stored Properties
 
     public let annotation: MKAnnotation
+    let clusteringIdentifier: String?
     let content: Content
 
     // MARK: Initialization
@@ -49,17 +50,21 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
         coordinate: CLLocationCoordinate2D,
         title: String? = nil,
         subtitle: String? = nil,
+        clusteringIdentifier: String? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = Annotation(coordinate: coordinate, title: title, subtitle: subtitle)
+        self.clusteringIdentifier = clusteringIdentifier
         self.content = content()
     }
 
     public init(
         annotation: MKAnnotation,
+        clusteringIdentifier: String? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = annotation
+        self.clusteringIdentifier = clusteringIdentifier
         self.content = content()
     }
 

--- a/Sources/Configuration/MapInformationVisibility.swift
+++ b/Sources/Configuration/MapInformationVisibility.swift
@@ -53,30 +53,52 @@ public struct MapInformationVisibility: OptionSet {
 
     public static let `default`: MapInformationVisibility = {
         #if os(watchOS)
-        return MapInformationVisibility(rawValue: 0)
+        return []
         #else
-        return MapInformationVisibility(arrayLiteral: .buildings)
+        return [.buildings]
         #endif
     }()
 
     public static let all: MapInformationVisibility = {
+        var value = MapInformationVisibility()
+
+        #if !os(watchOS)
+        value.insert(.buildings)
+        #endif
+
+        #if !os(tvOS) && !os(watchOS)
+        value.insert(.compass)
+        #endif
+
         #if os(macOS) || targetEnvironment(macCatalyst)
-        if #available(macOS 11, macCatalyst 14, *) {
-            return MapInformationVisibility(arrayLiteral: .buildings, .compass, .pitchControl, .scale, .traffic, .userLocation, .zoomControls)
-        } else {
-            return MapInformationVisibility(arrayLiteral: .buildings, .compass, .scale, .traffic, .userLocation, .zoomControls)
-        }
-        #elseif os(iOS)
-        return MapInformationVisibility(arrayLiteral: .buildings, .compass, .scale, .traffic, .userLocation)
-        #elseif os(tvOS)
-        return MapInformationVisibility(arrayLiteral: .buildings, .scale, .traffic, .userLocation)
-        #elseif os(watchOS)
-        if #available(watchOS 6.1, *) {
-            return MapInformationVisibility(arrayLiteral: .userHeading, .userLocation)
-        } else {
-            return MapInformationVisibility(rawValue: 0)
+        if #available(macCatalyst 14, macOS 11, *) {
+            value.insert(.pitchControl)
         }
         #endif
+
+        #if !os(watchOS)
+        value.insert(.scale)
+        value.insert(.traffic)
+        #endif
+
+        #if os(watchOS)
+        if #available(watchOS 6.1, *) {
+            value.insert(.userHeading)
+            value.insert(.userLocation)
+        }
+        #else
+        value.insert(.userLocation)
+        #endif
+
+        #if os(macOS) || targetEnvironment(macCatalyst)
+        value.insert(.zoomControls)
+        #elseif targetEnvironment(macCatalyst)
+        if #available(macCatalyst 14, *) {
+            value.insert(.zoomControls)
+        }
+        #endif
+
+        return value
     }()
 
     // MARK: Stored Properties

--- a/Sources/Configuration/SingleValueBuilder.swift
+++ b/Sources/Configuration/SingleValueBuilder.swift
@@ -6,6 +6,7 @@
 //
 
 public typealias MapAnnotationBuilder = SingleValueBuilder<MapAnnotation>
+public typealias OptionalMapAnnotationBuilder = SingleValueBuilder<MapAnnotation?>
 
 #if !os(watchOS)
 public typealias MapOverlayBuilder = SingleValueBuilder<MapOverlay>

--- a/Sources/Configuration/UserTrackingMode.swift
+++ b/Sources/Configuration/UserTrackingMode.swift
@@ -1,0 +1,36 @@
+//
+//  UserTrackingMode.swift
+//  Map
+//
+//  Created by Paul Kraft on 09.02.23.
+//
+
+import MapKit
+
+public enum UserTrackingMode {
+
+    // MARK: Cases
+
+    case none
+    case follow
+
+    @available(macOS, unavailable)
+    case followWithHeading
+
+    // MARK: Computed Properties
+
+    @available(macOS 11, *)
+    var actualValue: MKUserTrackingMode {
+        switch self {
+        case .none:
+            return .none
+        case .follow:
+            return .follow
+        #if !os(macOS)
+        case .followWithHeading:
+            return .followWithHeading
+        #endif
+        }
+    }
+
+}

--- a/Sources/Map/Map+Coordinator.swift
+++ b/Sources/Map/Map+Coordinator.swift
@@ -308,7 +308,9 @@ extension Map {
                     }
                     return item
                 }
-                return view?.clusterAnnotation(content)?.view(for: mapView)
+                return view?
+                    .clusterAnnotation(clusterAnnotation, content)?
+                    .view(for: mapView)
             }
             guard let content = annotationContentByObject[ObjectIdentifier(annotation)] else {
                 return nil

--- a/Sources/Map/Map+Coordinator.swift
+++ b/Sources/Map/Map+Coordinator.swift
@@ -300,7 +300,9 @@ extension Map {
         }
 
         public func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-            if let clusterAnnotation = annotation as? MKClusterAnnotation {
+            if let content = annotationContentByObject[ObjectIdentifier(annotation)] {
+                return content.view(for: mapView)
+            } else if let clusterAnnotation = annotation as? MKClusterAnnotation {
                 let content = clusterAnnotation.memberAnnotations.compactMap { annotation -> AnnotationItems.Element? in
                     guard let item = annotationItemByObject[ObjectIdentifier(annotation)] else {
                         assertionFailure("Somehow a cluster contains an unknown annotation item.")
@@ -311,11 +313,9 @@ extension Map {
                 return view?
                     .clusterAnnotation(clusterAnnotation, content)?
                     .view(for: mapView)
-            }
-            guard let content = annotationContentByObject[ObjectIdentifier(annotation)] else {
+            } else {
                 return nil
             }
-            return content.view(for: mapView)
         }
 
         public func mapView(_ mapView: MKMapView, clusterAnnotationForMemberAnnotations memberAnnotations: [MKAnnotation]) -> MKClusterAnnotation {

--- a/Sources/Map/Map.swift
+++ b/Sources/Map/Map.swift
@@ -27,12 +27,11 @@ public struct Map<AnnotationItems: RandomAccessCollection, OverlayItems: RandomA
     let interactionModes: MapInteractionModes
 
     let usesUserTrackingMode: Bool
-
-    @available(macOS 11, *)
-    @Binding var userTrackingMode: MKUserTrackingMode
+    @Binding var userTrackingMode: UserTrackingMode
 
     let annotationItems: AnnotationItems
     let annotationContent: (AnnotationItems.Element) -> MapAnnotation
+    let clusterAnnotation: ([AnnotationItems.Element]) -> MapAnnotation?
 
     let overlayItems: OverlayItems
     let overlayContent: (OverlayItems.Element) -> MapOverlay
@@ -53,6 +52,7 @@ extension Map {
         interactionModes: MapInteractionModes = .all,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -67,6 +67,7 @@ extension Map {
         self._userTrackingMode = .constant(.none)
         self.annotationItems = annotationItems
         self.annotationContent = annotationContent
+        self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
     }
@@ -79,6 +80,7 @@ extension Map {
         interactionModes: MapInteractionModes = .all,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -93,6 +95,7 @@ extension Map {
         self._userTrackingMode = .constant(.none)
         self.annotationItems = annotationItems
         self.annotationContent = annotationContent
+        self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
     }
@@ -105,9 +108,10 @@ extension Map {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         showsUserLocation: Bool = false,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -127,6 +131,7 @@ extension Map {
         }
         self.annotationItems = annotationItems
         self.annotationContent = annotationContent
+        self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
     }
@@ -138,9 +143,10 @@ extension Map {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -160,6 +166,7 @@ extension Map {
         }
         self.annotationItems = annotationItems
         self.annotationContent = annotationContent
+        self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
     }
@@ -176,9 +183,10 @@ extension Map {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -198,6 +206,7 @@ extension Map {
         }
         self.annotationItems = annotationItems
         self.annotationContent = annotationContent
+        self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
     }
@@ -208,9 +217,10 @@ extension Map {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -230,6 +240,7 @@ extension Map {
         }
         self.annotationItems = annotationItems
         self.annotationContent = annotationContent
+        self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
     }
@@ -258,6 +269,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -269,6 +281,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             interactionModes: interactionModes,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -285,6 +298,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -296,6 +310,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             interactionModes: interactionModes,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -309,12 +324,13 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -327,6 +343,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -339,12 +356,13 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -357,6 +375,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -374,12 +393,13 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -392,6 +412,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -403,12 +424,13 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -421,6 +443,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -449,6 +472,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         interactionModes: MapInteractionModes = .all,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -465,6 +489,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             interactionModes: interactionModes,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
+            clusterAnnotation: clusterAnnotation,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -478,6 +503,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         interactionModes: MapInteractionModes = .all,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -494,6 +520,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             interactionModes: interactionModes,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
+            clusterAnnotation: clusterAnnotation,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -506,9 +533,10 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -526,6 +554,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
+            clusterAnnotation: clusterAnnotation,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -538,9 +567,10 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -558,6 +588,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
+            clusterAnnotation: clusterAnnotation,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -575,9 +606,10 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -595,6 +627,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
+            clusterAnnotation: clusterAnnotation,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -606,9 +639,10 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -626,6 +660,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
+            clusterAnnotation: clusterAnnotation,
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -655,6 +690,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -671,6 +707,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             interactionModes: interactionModes,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -687,6 +724,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -703,6 +741,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             interactionModes: interactionModes,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -715,12 +754,13 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -738,6 +778,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -750,12 +791,13 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>?,
+        userTrackingMode: Binding<UserTrackingMode>?,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -773,6 +815,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -792,12 +835,13 @@ extension Map
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -815,6 +859,7 @@ extension Map
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -826,12 +871,13 @@ extension Map
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
-        userTrackingMode: Binding<MKUserTrackingMode>? = nil,
+        userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
+        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -849,6 +895,7 @@ extension Map
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
+            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )

--- a/Sources/Map/Map.swift
+++ b/Sources/Map/Map.swift
@@ -31,7 +31,7 @@ public struct Map<AnnotationItems: RandomAccessCollection, OverlayItems: RandomA
 
     let annotationItems: AnnotationItems
     let annotationContent: (AnnotationItems.Element) -> MapAnnotation
-    let clusterAnnotation: ([AnnotationItems.Element]) -> MapAnnotation?
+    let clusterAnnotation: (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation?
 
     let overlayItems: OverlayItems
     let overlayContent: (OverlayItems.Element) -> MapOverlay
@@ -52,7 +52,7 @@ extension Map {
         interactionModes: MapInteractionModes = .all,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -80,7 +80,7 @@ extension Map {
         interactionModes: MapInteractionModes = .all,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -111,7 +111,7 @@ extension Map {
         userTrackingMode: Binding<UserTrackingMode>?,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -146,7 +146,7 @@ extension Map {
         userTrackingMode: Binding<UserTrackingMode>?,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -186,7 +186,7 @@ extension Map {
         userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -220,7 +220,7 @@ extension Map {
         userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -269,7 +269,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -281,7 +281,8 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             interactionModes: interactionModes,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -298,7 +299,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -310,7 +311,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             interactionModes: interactionModes,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -330,7 +331,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -343,7 +344,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -362,7 +363,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -375,7 +376,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -399,7 +400,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -412,7 +413,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -430,7 +431,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlayItems: OverlayItems,
         @MapOverlayBuilder overlayContent: @escaping (OverlayItems.Element) -> MapOverlay
     ) {
@@ -443,7 +444,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlayItems,
             overlayContent: overlayContent
         )
@@ -609,7 +610,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -642,7 +643,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         userTrackingMode: Binding<UserTrackingMode>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -690,7 +691,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -724,7 +725,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @MapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -760,7 +761,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @MapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -797,7 +798,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @MapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -815,7 +816,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -841,7 +842,7 @@ extension Map
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @MapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -859,7 +860,7 @@ extension Map
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )
@@ -877,7 +878,7 @@ extension Map
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
             return ViewMapAnnotation(annotation: annotation) {}
         },
-        @MapAnnotationBuilder clusterAnnotation: @escaping ([MKAnnotation]) -> MapAnnotation? = { _ in nil },
+        @MapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation) -> MapAnnotation? = { _ in nil },
         overlays: [MKOverlay] = [],
         @MapOverlayBuilder overlayContent: @escaping (MKOverlay) -> MapOverlay = { overlay in
             assertionFailure("Please provide an `overlayContent` closure for the values in `overlays`.")
@@ -895,7 +896,7 @@ extension Map
             userTrackingMode: userTrackingMode,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
-            clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
+            clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
             overlayItems: overlays.map(IdentifiableObject.init),
             overlayContent: { overlayContent($0.object) }
         )

--- a/Sources/Views/MapPitchControl.swift
+++ b/Sources/Views/MapPitchControl.swift
@@ -10,7 +10,7 @@
 import SwiftUI
 import MapKit
 
-@available(macOS 11, *)
+@available(macCatalyst 14, macOS 11, *)
 public struct MapPitchControl {
 
     // MARK: Stored Properties

--- a/Sources/Views/MapZoomControl.swift
+++ b/Sources/Views/MapZoomControl.swift
@@ -10,7 +10,7 @@
 import SwiftUI
 import MapKit
 
-@available(macOS 11, macCatalyst 14, *)
+@available(macCatalyst 14, macOS 11, *)
 public struct MapZoomControl {
 
     // MARK: Stored Properties


### PR DESCRIPTION
Changelog:

- Added clustering mechanism that allows to set clusteringIdentifiers and then create MapAnnotations on the fly

The code in here is highly experimental and not yet close to be ready for merging, but it is an idea on how to allow for clustering of annotations.