### PR TITLE
Fixed Annotations HitTesting & Added annotation anchor

### DIFF
--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -22,7 +22,7 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         annotation = mapAnnotation.annotation
         clusteringIdentifier = mapAnnotation.clusteringIdentifier
 
-        let controller = NativeHostingController(rootView: mapAnnotation.content)
+        let controller = NativeHostingController(rootView: mapAnnotation.content, ignoreSafeArea: true)
         addSubview(controller.view)
         bounds.size = controller.preferredContentSize
         self.controller = controller

--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -35,7 +35,7 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         backgroundColor = .clear
         #endif
 
-        let controller = NativeHostingController(rootView: mapAnnotation.content)
+        let controller = NativeHostingController(rootView: mapAnnotation.content, ignoreSafeArea: true)
 
         #if canImport(UIKit)
         controller.view.backgroundColor = .clear
@@ -54,6 +54,10 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         
         self.controller = controller
         self.invalidateIntrinsicContentSize()
+        
+        if let anchor = mapAnnotation.anchor {
+            centerOffset = .init(x: anchor.x * intrinsicContentFrame.width / 2, y: anchor.y * intrinsicContentFrame.height / 2)
+        }
     }
 
     // MARK: Overrides

--- a/Sources/Annotations/ViewMapAnnotation.swift
+++ b/Sources/Annotations/ViewMapAnnotation.swift
@@ -42,28 +42,33 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
 
     public let annotation: MKAnnotation
     let clusteringIdentifier: String?
+    let anchor: CGPoint?
     let content: Content
 
     // MARK: Initialization
 
     public init(
         coordinate: CLLocationCoordinate2D,
+        anchor: CGPoint = .init(x: 0, y: 0),
         title: String? = nil,
         subtitle: String? = nil,
         clusteringIdentifier: String? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = Annotation(coordinate: coordinate, title: title, subtitle: subtitle)
+        self.anchor = anchor
         self.clusteringIdentifier = clusteringIdentifier
         self.content = content()
     }
 
     public init(
         annotation: MKAnnotation,
+        anchor: CGPoint = .init(x: 0, y: 0),
         clusteringIdentifier: String? = nil,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = annotation
+        self.anchor = anchor
         self.clusteringIdentifier = clusteringIdentifier
         self.content = content()
     }

--- a/Sources/Directions/DirectionRequest.swift
+++ b/Sources/Directions/DirectionRequest.swift
@@ -1,0 +1,34 @@
+import MapKit
+
+public struct DirectionRequest {
+    public struct RouteAppearance {
+        public let lineWidth: CGFloat
+        public let strokeColor: NativeColor
+        
+        public init(lineWidth: CGFloat, strokeColor: NativeColor) {
+            self.lineWidth = lineWidth
+            self.strokeColor = strokeColor
+        }
+    }
+    
+    public let mkRequest: MKDirections.Request
+    public let routeAppearance: RouteAppearance
+    public let sourceAnnotation: MapAnnotation
+    public let destinationAnnotation: MapAnnotation
+    
+    public init(mkRequest: MKDirections.Request,
+                routeAppearance: RouteAppearance,
+                sourceAnnotation: MapAnnotation,
+                destinationAnnotation: MapAnnotation) {
+        self.mkRequest = mkRequest
+        self.routeAppearance = routeAppearance
+        self.sourceAnnotation = sourceAnnotation
+        self.destinationAnnotation = destinationAnnotation
+    }
+}
+
+extension DirectionRequest: Equatable {
+    public static func ==(lhs: DirectionRequest, rhs: DirectionRequest) -> Bool {
+        lhs.mkRequest == rhs.mkRequest
+    }
+}

--- a/Sources/Extensions/UIHostingController.swift
+++ b/Sources/Extensions/UIHostingController.swift
@@ -1,0 +1,51 @@
+//
+//  NativeHostingController.swift
+//  Map
+//
+//  Created by Paul Kraft on 25.04.22.
+//
+
+import SwiftUI
+
+#if !os(watchOS)
+extension UIHostingController {
+    /// This convenience init uses dynamic subclassing to disable safe area behaviour for a UIHostingController
+    /// This solves bugs with embedded SwiftUI views having redundant insets
+    /// More on this here: https://defagos.github.io/swiftui_collection_part3/
+    /// - Parameters:
+    ///   - rootView: The content View
+    ///   - ignoreSafeArea: Disables the safe area insets if true
+    convenience public init(rootView: Content, ignoreSafeArea: Bool) {
+        self.init(rootView: rootView)
+        
+        if ignoreSafeArea {
+            disableSafeArea()
+        }
+    }
+    
+    func disableSafeArea() {
+        guard let viewClass = object_getClass(view) else { return }
+        
+        let viewSubclassName = String(cString: class_getName(viewClass)).appending("_IgnoreSafeArea")
+        if let viewSubclass = NSClassFromString(viewSubclassName) {
+            object_setClass(view, viewSubclass)
+        }
+        else {
+            guard let viewClassNameUtf8 = (viewSubclassName as NSString).utf8String else { return }
+            guard let viewSubclass = objc_allocateClassPair(viewClass, viewClassNameUtf8, 0) else { return }
+            
+            if let method = class_getInstanceMethod(UIView.self, #selector(getter: UIView.safeAreaInsets)) {
+                let safeAreaInsets: @convention(block) (AnyObject) -> UIEdgeInsets = { _ in
+                    return .zero
+                }
+                class_addMethod(viewSubclass, #selector(getter: UIView.safeAreaInsets),
+                                imp_implementationWithBlock(safeAreaInsets),
+                                method_getTypeEncoding(method))
+            }
+            
+            objc_registerClassPair(viewSubclass)
+            object_setClass(view, viewSubclass)
+        }
+    }
+}
+#endif

--- a/Sources/Map/Map+Coordinator.swift
+++ b/Sources/Map/Map+Coordinator.swift
@@ -242,7 +242,7 @@ extension Map {
             if #available(macOS 11, *) {
                 let newTrackingMode = newView.userTrackingMode.actualValue
                 if newView.usesUserTrackingMode, mapView.userTrackingMode != newTrackingMode {
-                    mapView.userTrackingMode = newTrackingMode
+                    mapView.setUserTrackingMode(newTrackingMode, animated: true)
                 }
             }
         }

--- a/Sources/Map/Map+Coordinator.swift
+++ b/Sources/Map/Map+Coordinator.swift
@@ -47,15 +47,16 @@ extension Map {
         func update(_ mapView: MKMapView, from newView: Map, context: Context) {
             defer { view = newView }
             let animation = context.transaction.animation
+            let animated = animation != nil
             updateAnnotations(on: mapView, from: view, to: newView)
-            updateCamera(on: mapView, context: context, animated: animation != nil)
+            updateCamera(on: mapView, context: context, animated: animated)
             updateInformationVisibility(on: mapView, from: view, to: newView)
             updateInteractionModes(on: mapView, from: view, to: newView)
             updateOverlays(on: mapView, from: view, to: newView)
             updatePointOfInterestFilter(on: mapView, from: view, to: newView)
-            updateRegion(on: mapView, from: view, to: newView, animated: animation != nil)
+            updateRegion(on: mapView, from: view, to: newView, animated: animated)
             updateType(on: mapView, from: view, to: newView)
-            updateUserTracking(on: mapView, from: view, to: newView)
+            updateUserTracking(on: mapView, from: view, to: newView, animated: animated)
 
             if let key = context.environment.mapKey {
                 MapRegistry[key] = mapView
@@ -238,11 +239,11 @@ extension Map {
             }
         }
 
-        private func updateUserTracking(on mapView: MKMapView, from previousView: Map?, to newView: Map) {
+        private func updateUserTracking(on mapView: MKMapView, from previousView: Map?, to newView: Map, animated: Bool) {
             if #available(macOS 11, *) {
                 let newTrackingMode = newView.userTrackingMode.actualValue
                 if newView.usesUserTrackingMode, mapView.userTrackingMode != newTrackingMode {
-                    mapView.setUserTrackingMode(newTrackingMode, animated: true)
+                    mapView.setUserTrackingMode(newTrackingMode, animated: animated)
                 }
             }
         }

--- a/Sources/Map/Map+Coordinator.swift
+++ b/Sources/Map/Map+Coordinator.swift
@@ -23,10 +23,12 @@ extension Map {
         private var annotationContentByObject = [ObjectIdentifier: MapAnnotation]()
         private var annotationItemByObject = [ObjectIdentifier: AnnotationItems.Element]()
         private var annotationContentByID = [AnnotationItems.Element.ID: MapAnnotation]()
-
+        private var directionsAnnotations: [MKAnnotation] = []
+        
         private var overlayContentByObject = [ObjectIdentifier: MapOverlay]()
         private var overlayContentByID = [OverlayItems.Element.ID: MapOverlay]()
-
+        private var directionsOverlay: MapOverlay? = nil
+        
         private var previousBoundary: MKMapView.CameraBoundary?
         private var previousZoomRange: MKMapView.CameraZoomRange?
 
@@ -57,7 +59,8 @@ extension Map {
             updateRegion(on: mapView, from: view, to: newView, animated: animated)
             updateType(on: mapView, from: view, to: newView)
             updateUserTracking(on: mapView, from: view, to: newView, animated: animated)
-
+            updateDirections(on: mapView, from: view, to: newView, animated: animated)
+            
             if let key = context.environment.mapKey {
                 MapRegistry[key] = mapView
             }
@@ -247,6 +250,52 @@ extension Map {
                 }
             }
         }
+        
+        private func updateDirections(on mapView: MKMapView, from previousView: Map?, to newView: Map, animated: Bool) {
+            guard previousView?.directionsRequest != newView.directionsRequest else {
+                return
+            }
+            
+            let isNewDirection = newView.directionsRequest != nil && previousView?.directionsRequest != nil
+            
+            // Remove overlay and annotations from the mapView
+            if newView.directionsRequest == nil || isNewDirection {
+                if let directionsOverlay = directionsOverlay {
+                    mapView.removeOverlay(directionsOverlay.overlay)
+                }
+                mapView.removeAnnotations(directionsAnnotations)
+                directionsAnnotations = []
+                directionsOverlay = nil
+            }
+            
+            guard let directionsRequest = newView.directionsRequest,
+                  let mkRequest = newView.directionsRequest?.mkRequest else {
+                return
+            }
+            
+            let directions = MKDirections(request: mkRequest)
+            directions.calculate { response, error in
+                guard let route = response?.routes.first else { return }
+                let directionsOverlay = MapPolyline(
+                    polyline: route.polyline,
+                    strokeColor: directionsRequest.routeAppearance.strokeColor,
+                    lineWidth: directionsRequest.routeAppearance.lineWidth
+                )
+                self.directionsOverlay = directionsOverlay
+                self.directionsAnnotations = [
+                    directionsRequest.sourceAnnotation.annotation,
+                    directionsRequest.destinationAnnotation.annotation
+                ]
+                mapView.addAnnotations(self.directionsAnnotations)
+                
+                mapView.addOverlay(directionsOverlay.overlay)
+                mapView.setVisibleMapRect(
+                    route.polyline.boundingMapRect,
+                    edgePadding: UIEdgeInsets(top: 50, left: 50, bottom: 50, right: 50),
+                    animated: animated
+                )
+            }
+        }
 
         // MARK: MKMapViewDelegate
 
@@ -297,9 +346,13 @@ extension Map {
         }
 
         public func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let directionsOverlay = directionsOverlay, ObjectIdentifier(directionsOverlay.overlay) == ObjectIdentifier(overlay) {
+                return directionsOverlay.renderer(for: mapView)
+            }
             guard let content = overlayContentByObject[ObjectIdentifier(overlay)] else {
                 assertionFailure("Somehow an unknown overlay appeared.")
                 return MKOverlayRenderer(overlay: overlay)
+                
             }
             return content.renderer(for: mapView)
         }

--- a/Sources/Map/Map+Coordinator.swift
+++ b/Sources/Map/Map+Coordinator.swift
@@ -253,8 +253,10 @@ extension Map {
             guard !regionIsChanging else {
                 return
             }
-            view?.coordinateRegion = mapView.region
-            view?.mapRect = mapView.visibleMapRect
+            DispatchQueue.main.async { [weak self] in
+                self?.view?.coordinateRegion = mapView.region
+                self?.view?.mapRect = mapView.visibleMapRect
+            }
         }
 
         @available(macOS 11, *)
@@ -262,19 +264,21 @@ extension Map {
             guard let view = view, view.usesUserTrackingMode else {
                 return
             }
-            switch mode {
-            case .none:
-                view.userTrackingMode = .none
-            case .follow:
-                view.userTrackingMode = .follow
-            case .followWithHeading:
-                #if os(macOS) || os(tvOS)
-                view.userTrackingMode = .follow
-                #else
-                view.userTrackingMode = .followWithHeading
-                #endif
-            @unknown default:
-                assertionFailure("Encountered unknown user tracking mode")
+            DispatchQueue.main.async {
+                switch mode {
+                case .none:
+                    view.userTrackingMode = .none
+                case .follow:
+                    view.userTrackingMode = .follow
+                case .followWithHeading:
+                    #if os(macOS) || os(tvOS)
+                    view.userTrackingMode = .follow
+                    #else
+                    view.userTrackingMode = .followWithHeading
+                    #endif
+                @unknown default:
+                    assertionFailure("Encountered unknown user tracking mode")
+                }
             }
         }
 

--- a/Sources/Map/Map+Watch+Coordinator.swift
+++ b/Sources/Map/Map+Watch+Coordinator.swift
@@ -11,12 +11,11 @@ import MapKit
 import SwiftUI
 import WatchKit
 
+@available(watchOS 6.1, *)
 extension Map: WKInterfaceObjectRepresentable {
-
     // MARK: Nested Types
 
     public class Coordinator {
-
         // MARK: Stored Properties
 
         private var view: Map?
@@ -30,16 +29,14 @@ extension Map: WKInterfaceObjectRepresentable {
             let animation = context.transaction.animation
             updateAnnotations(on: mapView, from: view, to: newView)
             updateRegion(on: mapView, from: view, to: newView)
-            if #available(watchOS 6.1, *) {
-                updateUserTracking(on: mapView, from: view, to: newView, animated: animation != nil)
-            }
+            updateUserTracking(on: mapView, from: view, to: newView, animated: animation != nil)
         }
 
         // MARK: Helpers
 
         private func updateAnnotations(on mapView: WKInterfaceMap, from previousView: Map?, to newView: Map) {
             let changes: CollectionDifference<AnnotationItems.Element>
-            if let previousView = previousView {
+            if let previousView {
                 changes = newView.annotationItems.difference(from: previousView.annotationItems) { $0.id == $1.id }
             } else {
                 changes = newView.annotationItems.difference(from: []) { $0.id == $1.id }
@@ -92,7 +89,6 @@ extension Map: WKInterfaceObjectRepresentable {
                 mapView.setUserTrackingMode(newView.userTrackingMode, animated: animated)
             }
         }
-
     }
 
     // MARK: Methods
@@ -110,7 +106,6 @@ extension Map: WKInterfaceObjectRepresentable {
     public func updateWKInterfaceObject(_ mapView: WKInterfaceMap, context: Context) {
         context.coordinator.update(mapView, from: self, context: context)
     }
-
 }
 
 #endif

--- a/Sources/Map/Map+Watch.swift
+++ b/Sources/Map/Map+Watch.swift
@@ -11,6 +11,7 @@ import MapKit
 import SwiftUI
 import WatchKit
 
+@available(watchOS 6.1, *)
 public struct Map<AnnotationItems: RandomAccessCollection> where AnnotationItems.Element: Identifiable {
 
     // MARK: Stored Properties
@@ -23,7 +24,6 @@ public struct Map<AnnotationItems: RandomAccessCollection> where AnnotationItems
     let informationVisibility: MapInformationVisibility
     let usesUserTrackingMode: Bool
 
-    @available(watchOS 6.1, *)
     @Binding var userTrackingMode: WKInterfaceMap.UserTrackingMode
 
     let annotationItems: AnnotationItems
@@ -33,6 +33,7 @@ public struct Map<AnnotationItems: RandomAccessCollection> where AnnotationItems
 
 // MARK: - Initialization
 
+@available(watchOS 6.1, *)
 extension Map {
 
     public init(
@@ -115,6 +116,7 @@ extension Map {
 
 }
 
+@available(watchOS 6.1, *)
 extension Map where AnnotationItems == EmptyCollection<IdentifiableObject<NSObject>> {
 
     public init(

--- a/Sources/Map/Map.swift
+++ b/Sources/Map/Map.swift
@@ -17,6 +17,7 @@ public struct Map<AnnotationItems: RandomAccessCollection, OverlayItems: RandomA
 
     @Binding var coordinateRegion: MKCoordinateRegion
     @Binding var mapRect: MKMapRect
+    @Binding var directionsRequest: DirectionRequest?
 
     let usesRegion: Bool
 
@@ -50,6 +51,7 @@ extension Map {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
@@ -70,6 +72,11 @@ extension Map {
         self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
+        if let directionsRequest = directionsRequest {
+            self._directionsRequest = directionsRequest
+        } else {
+            self._directionsRequest = .constant(nil)
+        }
     }
 
     public init(
@@ -78,6 +85,7 @@ extension Map {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
@@ -98,6 +106,11 @@ extension Map {
         self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
+        if let directionsRequest = directionsRequest {
+            self._directionsRequest = directionsRequest
+        } else {
+            self._directionsRequest = .constant(nil)
+        }
     }
 
     @available(macOS 11, *)
@@ -109,6 +122,7 @@ extension Map {
         interactionModes: MapInteractionModes = .all,
         showsUserLocation: Bool = false,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
@@ -134,6 +148,11 @@ extension Map {
         self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
+        if let directionsRequest = directionsRequest {
+            self._directionsRequest = directionsRequest
+        } else {
+            self._directionsRequest = .constant(nil)
+        }
     }
 
     @available(macOS 11, *)
@@ -144,6 +163,7 @@ extension Map {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
@@ -169,6 +189,11 @@ extension Map {
         self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
+        if let directionsRequest = directionsRequest {
+            self._directionsRequest = directionsRequest
+        } else {
+            self._directionsRequest = .constant(nil)
+        }
     }
 
 }
@@ -184,6 +209,7 @@ extension Map {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
@@ -209,6 +235,11 @@ extension Map {
         self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
+        if let directionsRequest = directionsRequest {
+            self._directionsRequest = directionsRequest
+        } else {
+            self._directionsRequest = .constant(nil)
+        }
     }
 
     public init(
@@ -218,6 +249,7 @@ extension Map {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
@@ -243,6 +275,11 @@ extension Map {
         self.clusterAnnotation = clusterAnnotation
         self.overlayItems = overlayItems
         self.overlayContent = overlayContent
+        if let directionsRequest = directionsRequest {
+            self._directionsRequest = directionsRequest
+        } else {
+            self._directionsRequest = .constant(nil)
+        }
     }
 
 }
@@ -264,6 +301,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -279,6 +317,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             pointOfInterestFilter: pointOfInterestFilter,
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -294,6 +333,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -309,6 +349,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             pointOfInterestFilter: pointOfInterestFilter,
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -326,6 +367,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -342,6 +384,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -358,6 +401,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -374,6 +418,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -395,6 +440,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -411,6 +457,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -426,6 +473,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -442,6 +490,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -471,6 +520,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
@@ -488,6 +538,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             pointOfInterestFilter: pointOfInterestFilter,
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
+            directionsRequest: directionsRequest,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
             clusterAnnotation: clusterAnnotation,
@@ -502,6 +553,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
@@ -519,6 +571,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             pointOfInterestFilter: pointOfInterestFilter,
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
+            directionsRequest: directionsRequest,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
             clusterAnnotation: clusterAnnotation,
@@ -535,6 +588,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
@@ -553,6 +607,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
             clusterAnnotation: clusterAnnotation,
@@ -569,6 +624,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping ([AnnotationItems.Element]) -> MapAnnotation? = { _ in nil },
@@ -587,6 +643,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
             clusterAnnotation: clusterAnnotation,
@@ -608,6 +665,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
@@ -626,6 +684,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
             clusterAnnotation: clusterAnnotation,
@@ -641,6 +700,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotationItems: AnnotationItems,
         @MapAnnotationBuilder annotationContent: @escaping (AnnotationItems.Element) -> MapAnnotation,
         @OptionalMapAnnotationBuilder clusterAnnotation: @escaping (MKClusterAnnotation, [AnnotationItems.Element]) -> MapAnnotation? = { _, _ in nil },
@@ -659,6 +719,7 @@ extension Map where OverlayItems == [IdentifiableObject<MKOverlay>] {
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotationItems,
             annotationContent: annotationContent,
             clusterAnnotation: clusterAnnotation,
@@ -686,6 +747,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -706,6 +768,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             pointOfInterestFilter: pointOfInterestFilter,
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
@@ -720,6 +783,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
         pointOfInterestFilter: MKPointOfInterestFilter? = nil,
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -740,6 +804,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             pointOfInterestFilter: pointOfInterestFilter,
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
@@ -756,6 +821,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -777,6 +843,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { clusterAnnotation($0.map(\.object)) },
@@ -793,6 +860,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>?,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -814,6 +882,7 @@ extension Map where AnnotationItems == [IdentifiableObject<MKAnnotation>], Overl
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -837,6 +906,7 @@ extension Map
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -858,6 +928,7 @@ extension Map
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },
@@ -873,6 +944,7 @@ extension Map
         informationVisibility: MapInformationVisibility = .default,
         interactionModes: MapInteractionModes = .all,
         userTrackingMode: Binding<UserTrackingMode>? = nil,
+        directionsRequest: Binding<DirectionRequest?>? = nil,
         annotations: [MKAnnotation] = [],
         @MapAnnotationBuilder annotationContent: @escaping (MKAnnotation) -> MapAnnotation = { annotation in
             assertionFailure("Please provide an `annotationContent` closure for the values in `annotations`.")
@@ -894,6 +966,7 @@ extension Map
             informationVisibility: informationVisibility,
             interactionModes: interactionModes,
             userTrackingMode: userTrackingMode,
+            directionsRequest: directionsRequest,
             annotationItems: annotations.map(IdentifiableObject.init),
             annotationContent: { annotationContent($0.object) },
             clusterAnnotation: { annotation, _ in clusterAnnotation(annotation) },


### PR DESCRIPTION
This PR implements several fixes and enchantments:
1. Clickable SwiftUI Annotations! #4 
2. Added `anchor` parameter to the `ViewMapAnnotation` similar to the default SwiftUI Map approach.
3. Fixed annotations centering problem #14. Thanks to @rderimay (I took solution from #25)

P.S.
@pauljohanneskraft 
The problem with your hittesting solution in the hit-testing branch was that the SwiftUI annotation view was not constrained to the underlying UIView. Therefore, when you moved the map, the SwiftUI view's position did not change. You may see in the picture below.
<img width="408" alt="Снимок экрана 2023-03-04 в 21 59 45" src="https://user-images.githubusercontent.com/29120192/222954705-6ff2c4e1-a244-4c0c-8182-4de8e7014798.png">
