### PR TITLE
Allow `displayPriority` and `collisionMode` to pass-through to `MKAnnotationView`.

### DIFF
--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -21,6 +21,8 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
     func setup(for mapAnnotation: ViewMapAnnotation<Content>) {
         annotation = mapAnnotation.annotation
         clusteringIdentifier = mapAnnotation.clusteringIdentifier
+        displayPriority = mapAnnotation.displayPriority
+        collisionMode = mapAnnotation.collisionMode
 
         let controller = NativeHostingController(rootView: mapAnnotation.content)
         addSubview(controller.view)

--- a/Sources/Annotations/ViewMapAnnotation.swift
+++ b/Sources/Annotations/ViewMapAnnotation.swift
@@ -42,6 +42,8 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
 
     public let annotation: MKAnnotation
     let clusteringIdentifier: String?
+    let displayPriority: MKFeatureDisplayPriority
+    let collisionMode: MKAnnotationView.CollisionMode
     let content: Content
 
     // MARK: Initialization
@@ -51,20 +53,28 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
         title: String? = nil,
         subtitle: String? = nil,
         clusteringIdentifier: String? = nil,
+        displayPriority: MKFeatureDisplayPriority = .required,
+        collisionMode: MKAnnotationView.CollisionMode = .rectangle,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = Annotation(coordinate: coordinate, title: title, subtitle: subtitle)
         self.clusteringIdentifier = clusteringIdentifier
+        self.displayPriority = displayPriority
+        self.collisionMode = collisionMode
         self.content = content()
     }
 
     public init(
         annotation: MKAnnotation,
         clusteringIdentifier: String? = nil,
+        displayPriority: MKFeatureDisplayPriority = .required,
+        collisionMode: MKAnnotationView.CollisionMode = .rectangle,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = annotation
         self.clusteringIdentifier = clusteringIdentifier
+        self.displayPriority = displayPriority
+        self.collisionMode = collisionMode
         self.content = content()
     }
 


### PR DESCRIPTION
I needed to be able to set [displayPriority](https://developer.apple.com/documentation/mapkit/mkannotationview/2867298-displaypriority) and [collisionMode](https://developer.apple.com/documentation/mapkit/mkannotationview/2873315-collisionmode) of the `MKAnnotationView` that gets built from the `ViewMapAnnotation`.

This PR exposes these values as properties of `ViewMapAnnotation`, and `MKMapAnnotationView` sets them on the view during the `setup` process.