### PR TITLE
Add `anchorPoint` to `ViewMapAnnotation`

### DIFF
--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -38,11 +38,15 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         controller.view.backgroundColor = .clear
         #endif
         
+        #if canImport(UIKit)
         if #available(iOS 16, *) {
             anchorPoint = mapAnnotation.anchorPoint.toCGPoint()
         } else {
             centerOffset = mapAnnotation.anchorPoint.toCenterOffset(in: bounds)
         }
+        #else
+        centerOffset = mapAnnotation.anchorPoint.toCenterOffset(in: bounds)
+        #endif
     }
 
     // MARK: Overrides

--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -15,12 +15,15 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
     // MARK: Stored Properties
 
     private var controller: NativeHostingController<Content>?
+    private var mapAnnotation: ViewMapAnnotation<Content>?
 
     // MARK: Methods
 
     func setup(for mapAnnotation: ViewMapAnnotation<Content>) {
+        self.mapAnnotation = mapAnnotation
         annotation = mapAnnotation.annotation
         clusteringIdentifier = mapAnnotation.clusteringIdentifier
+        
         displayPriority = mapAnnotation.displayPriority
         collisionMode = mapAnnotation.collisionMode
 
@@ -28,7 +31,25 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         addSubview(controller.view)
         bounds.size = controller.preferredContentSize
         self.controller = controller
+        
+        if #available(iOS 16, *) {
+            anchorPoint = mapAnnotation.anchorPoint
+        } else {
+            centerOffset = anchorPointToCenterOffset(mapAnnotation.anchorPoint, in: bounds)
+        }
     }
+
+    // Only necessary for iOS < 16, where `anchorPoint` is not available on `UIView`
+    func anchorPointToCenterOffset(_ anchorPoint: CGPoint, in rect: CGRect) -> CGPoint {
+        assert((0.0...1.0).contains(anchorPoint.x), "Valid anchor point range is 0.0 to 1.0, received x value: \(anchorPoint.x)")
+        assert((0.0...1.0).contains(anchorPoint.y), "Valid anchor point range is 0.0 to 1.0, received y value: \(anchorPoint.y)")
+
+        return .init(
+            x: (0.5 - anchorPoint.x) * rect.width,
+            y: (0.5 - anchorPoint.y) * rect.height
+        )
+    }
+
 
     // MARK: Overrides
 
@@ -36,9 +57,14 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        
+        guard let controller else {
+            return
+        }
 
-        if let controller = controller {
-            bounds.size = controller.preferredContentSize
+        bounds.size = controller.preferredContentSize
+        if #unavailable(iOS 16), let mapAnnotation {
+            centerOffset = anchorPointToCenterOffset(mapAnnotation.anchorPoint, in: bounds)
         }
     }
 
@@ -53,6 +79,9 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         controller?.view.removeFromSuperview()
         controller?.removeFromParent()
         controller = nil
+        
+        mapAnnotation = nil
+        annotation = nil
     }
 
 }

--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -21,6 +21,8 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
     func setup(for mapAnnotation: ViewMapAnnotation<Content>) {
         annotation = mapAnnotation.annotation
         clusteringIdentifier = mapAnnotation.clusteringIdentifier
+        displayPriority = mapAnnotation.displayPriority
+        collisionMode = mapAnnotation.collisionMode
 
         let controller = NativeHostingController(rootView: mapAnnotation.content)
         addSubview(controller.view)

--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -33,6 +33,10 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         frame.size = controller.view.intrinsicContentSize
         addSubview(controller.view)
         controller.view.frame = bounds
+
+        #if canImport(UIKit)
+        controller.view.backgroundColor = .clear
+        #endif
         
         if #available(iOS 16, *) {
             anchorPoint = mapAnnotation.anchorPoint

--- a/Sources/Annotations/MKMapAnnotationView.swift
+++ b/Sources/Annotations/MKMapAnnotationView.swift
@@ -39,23 +39,11 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         #endif
         
         if #available(iOS 16, *) {
-            anchorPoint = mapAnnotation.anchorPoint
+            anchorPoint = mapAnnotation.anchorPoint.toCGPoint()
         } else {
-            centerOffset = anchorPointToCenterOffset(mapAnnotation.anchorPoint, in: bounds)
+            centerOffset = mapAnnotation.anchorPoint.toCenterOffset(in: bounds)
         }
     }
-
-    // Only necessary for iOS < 16, where `anchorPoint` is not available on `UIView`
-    func anchorPointToCenterOffset(_ anchorPoint: CGPoint, in rect: CGRect) -> CGPoint {
-        assert((0.0...1.0).contains(anchorPoint.x), "Valid anchor point range is 0.0 to 1.0, received x value: \(anchorPoint.x)")
-        assert((0.0...1.0).contains(anchorPoint.y), "Valid anchor point range is 0.0 to 1.0, received y value: \(anchorPoint.y)")
-
-        return .init(
-            x: (0.5 - anchorPoint.x) * rect.width,
-            y: (0.5 - anchorPoint.y) * rect.height
-        )
-    }
-    
 
     // MARK: Overrides
 
@@ -75,9 +63,9 @@ class MKMapAnnotationView<Content: View>: MKAnnotationView {
         // MKAnnotationView's around in non-standard ways.
         controller.view.frame = .zero
         controller.view.frame = bounds
-
+        
         if #unavailable(iOS 16), let mapAnnotation {
-            centerOffset = anchorPointToCenterOffset(mapAnnotation.anchorPoint, in: bounds)
+            centerOffset = mapAnnotation.anchorPoint.toCenterOffset(in: bounds)
         }
     }
 

--- a/Sources/Annotations/ViewMapAnnotation.swift
+++ b/Sources/Annotations/ViewMapAnnotation.swift
@@ -41,7 +41,7 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
     // MARK: Stored Properties
 
     public let annotation: MKAnnotation
-    let anchorPoint: CGPoint
+    let anchorPoint: UnitPoint
     let clusteringIdentifier: String?
     let displayPriority: MKFeatureDisplayPriority
     let collisionMode: MKAnnotationView.CollisionMode
@@ -53,7 +53,7 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
         coordinate: CLLocationCoordinate2D,
         title: String? = nil,
         subtitle: String? = nil,
-        anchorPoint: CGPoint = .init(x: 0.5, y: 0.5),
+        anchorPoint: UnitPoint = .center,
         clusteringIdentifier: String? = nil,
         displayPriority: MKFeatureDisplayPriority = .required,
         collisionMode: MKAnnotationView.CollisionMode = .rectangle,
@@ -69,7 +69,7 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
 
     public init(
         annotation: MKAnnotation,
-        anchorPoint: CGPoint = .init(x: 0.5, y: 0.5),
+        anchorPoint: UnitPoint = .center,
         clusteringIdentifier: String? = nil,
         displayPriority: MKFeatureDisplayPriority = .required,
         collisionMode: MKAnnotationView.CollisionMode = .rectangle,

--- a/Sources/Annotations/ViewMapAnnotation.swift
+++ b/Sources/Annotations/ViewMapAnnotation.swift
@@ -42,6 +42,8 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
 
     public let annotation: MKAnnotation
     let clusteringIdentifier: String?
+    let displayPriority: MKFeatureDisplayPriority
+    let collisionMode: MKAnnotationView.CollisionMode
     let content: Content
 
     // MARK: Initialization
@@ -51,20 +53,28 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
         title: String? = nil,
         subtitle: String? = nil,
         clusteringIdentifier: String? = nil,
+        displayPriority: MKFeatureDisplayPriority = .required,
+        collisionMode: MKAnnotationView.CollisionMode = .rectangle,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = Annotation(coordinate: coordinate, title: title, subtitle: subtitle)
         self.clusteringIdentifier = clusteringIdentifier
+        self.displayPriority = displayPriority
+        self.collisionMode = collisionMode
         self.content = content()
     }
 
     public init(
         annotation: MKAnnotation,
         clusteringIdentifier: String? = nil,
+        displayPriority: MKFeatureDisplayPriority = .required,
+        collisionMode: MKAnnotationView.CollisionMode = .rectangle,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = annotation
         self.clusteringIdentifier = clusteringIdentifier
+        self.displayPriority = displayPriority
+        self.collisionMode = collisionMode
         self.content = content()
     }
 

--- a/Sources/Annotations/ViewMapAnnotation.swift
+++ b/Sources/Annotations/ViewMapAnnotation.swift
@@ -41,6 +41,7 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
     // MARK: Stored Properties
 
     public let annotation: MKAnnotation
+    let anchorPoint: CGPoint
     let clusteringIdentifier: String?
     let displayPriority: MKFeatureDisplayPriority
     let collisionMode: MKAnnotationView.CollisionMode
@@ -52,12 +53,14 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
         coordinate: CLLocationCoordinate2D,
         title: String? = nil,
         subtitle: String? = nil,
+        anchorPoint: CGPoint = .init(x: 0.5, y: 0.5),
         clusteringIdentifier: String? = nil,
         displayPriority: MKFeatureDisplayPriority = .required,
         collisionMode: MKAnnotationView.CollisionMode = .rectangle,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = Annotation(coordinate: coordinate, title: title, subtitle: subtitle)
+        self.anchorPoint = anchorPoint
         self.clusteringIdentifier = clusteringIdentifier
         self.displayPriority = displayPriority
         self.collisionMode = collisionMode
@@ -66,12 +69,14 @@ public struct ViewMapAnnotation<Content: View>: MapAnnotation {
 
     public init(
         annotation: MKAnnotation,
+        anchorPoint: CGPoint = .init(x: 0.5, y: 0.5),
         clusteringIdentifier: String? = nil,
         displayPriority: MKFeatureDisplayPriority = .required,
         collisionMode: MKAnnotationView.CollisionMode = .rectangle,
         @ViewBuilder content: () -> Content
     ) {
         self.annotation = annotation
+        self.anchorPoint = anchorPoint
         self.clusteringIdentifier = clusteringIdentifier
         self.displayPriority = displayPriority
         self.collisionMode = collisionMode

--- a/Sources/Extensions/UnitPoint.swift
+++ b/Sources/Extensions/UnitPoint.swift
@@ -1,0 +1,23 @@
+//
+//  UnitPoint.swift
+//  Map
+//
+//  Created by Darron Schall on 10/2/23.
+//
+
+import SwiftUI
+
+extension UnitPoint {
+    
+    func toCGPoint() -> CGPoint {
+        return CGPoint(x: x, y: y)
+    }
+
+    func toCenterOffset(in rect: CGRect) -> CGPoint {
+        return CGPoint(
+            x: (0.5 - x) * rect.width,
+            y: (0.5 - y) * rect.height
+        )
+    }
+
+}


### PR DESCRIPTION
NOTE: This builds on #48, since I also needed those attributes to help control how my markers cluster. If #48 gets merged first, this PR will be slightly easier to review.

I originally tried just adding `anchorPoint` to `ViewMapAnnotation` and passing it through to the `MKMapAnnotationView` (using [`UIView`'s `anchorPoint`](https://developer.apple.com/documentation/uikit/uiview/4051982-anchorpoint) if available, otherwise falling back on [`centerOffset`](https://developer.apple.com/documentation/mapkit/mkannotationview/1452144-centeroffset)), but the anchor point wasn't applying correctly.

I borrowed from @allenhumphreys PR #40 to get the frame and the anchor point to apply correctly. I wasn't sure if that PR was ever going to get merged; I took the minimum changes necessary to get anchor point working in hopes of getting this PR merged.

I also looked at ideas in #38, which seems somewhat related. This could potentially fix #14 as well; I've noticed that my pins have a much more consistent location now during zoom/pan and seem to be anchored properly in the correct location.

My first pass made anchorPoint a `CGPoint`, but I decided it would be better to use [`UnitPoint`](https://developer.apple.com/documentation/swiftui/unitpoint) as that's more SwiftUI-y. I can change it back to `CGPoint` if you prefer.

FWIW, I'm using this branch successfully in an iOS app, and I have pin-style markers. Setting `anchorPoint: .bottom` (the bottom middle of the marker) keeps the pins in the correct location as the user moves the map around in my app.